### PR TITLE
chore: update foyer link

### DIFF
--- a/material/home.html
+++ b/material/home.html
@@ -282,7 +282,7 @@ console.log(exists); // Outputs: false</code>
       <a target="_blank" class="custom-link-text"
         href="https://github.com/falsandtru/spica/blob/master/src/s3-fifo.ts">spica (Javascript)</a>,
       <a target="_blank" class="custom-link-text"
-        href="https://github.com/MrCroxx/foyer/pull/303">foyer (Rust)</a>,
+        href="https://github.com/foyer-rs/foyer/pull/303">foyer (Rust)</a>,
       <br>
       and many other cache libraries in
       Golang 


### PR DESCRIPTION
Hi, thank you for showing `foyer` in the S3-FIFO homepage.

The foyer repo has been moved to foyer-rs/foyer. Let's update it here.